### PR TITLE
[TEST] fix: enable strict mode for CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,8 @@ jobs:
       with:
         go-version: "1.19.7"
     - run: |
+        set -euo pipefail
+
         git config --global user.email "github-action@etcd.io"
         git config --global user.name "Github Action"
         gpg --batch --gen-key <<EOF

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,6 +25,8 @@ jobs:
     - env:
         TARGET: ${{ matrix.target }}
       run: |
+        set -euo pipefail
+
         go version
         echo ${GOROOT}
         echo "${TARGET}"
@@ -58,8 +60,7 @@ jobs:
             GO_BUILD_FLAGS='-v' GOARCH=s390x ./build
             ;;
           linux-amd64-grpcproxy)
-            PASSES='build grpcproxy' CPU='4' RACE='true' ./test 2>&1 | tee test.log
-            ! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
+            PASSES='build grpcproxy' CPU='4' RACE='true' ./test
             ;;
           linux-386-unit)
             GOARCH=386 PASSES='unit' ./test

--- a/build
+++ b/build
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # set some environment variables
 ORG_PATH="go.etcd.io"
 REPO_PATH="${ORG_PATH}/etcd"
 
 GIT_SHA=$(git rev-parse --short HEAD || echo "GitNotFound")
-if [[ -n "$FAILPOINTS" ]]; then
+if [[ -n "${FAILPOINTS:-}" ]]; then
 	GIT_SHA="$GIT_SHA"-FAILPOINTS
 fi
 
 # Set GO_LDFLAGS="-s" for building without symbols for debugging.
-GO_LDFLAGS="$GO_LDFLAGS -X ${REPO_PATH}/version.GitSHA=${GIT_SHA}"
+GO_LDFLAGS="${GO_LDFLAGS:-} -X ${REPO_PATH}/version.GitSHA=${GIT_SHA}"
 
 # enable/disable failpoints
 toggle_failpoints() {
@@ -30,7 +32,7 @@ etcd_setup_gopath() {
 	cd "$CDIR" || return
 	etcdGOPATH="${CDIR}/gopath"
 	# preserve old gopath to support building with unvendored tooling deps (e.g., gofail)
-	if [[ -n "$GOPATH" ]]; then
+	if [[ -n "${GOPATH:-}" ]]; then
 		GOPATH=":$GOPATH"
 	fi
 	rm -rf "${etcdGOPATH:?}/"
@@ -42,23 +44,23 @@ etcd_setup_gopath() {
 
 toggle_failpoints_default() {
 	mode="disable"
-	if [[ -n "$FAILPOINTS" ]]; then mode="enable"; fi
+	if [[ -n "${FAILPOINTS:-}" ]]; then mode="enable"; fi
 	toggle_failpoints "$mode"
 }
 
 etcd_build() {
 	out="bin"
-	if [[ -n "${BINDIR}" ]]; then out="${BINDIR}"; fi
+	if [[ -n "${BINDIR:-}" ]]; then out="${BINDIR}"; fi
 	toggle_failpoints_default
 
 	# Static compilation is useful when etcd is run in a container. $GO_BUILD_FLAGS is OK
 	# shellcheck disable=SC2086
-	CGO_ENABLED=0 go build $GO_BUILD_FLAGS \
+	CGO_ENABLED=0 go build ${GO_BUILD_FLAGS:-} \
 		-installsuffix cgo \
 		-ldflags "$GO_LDFLAGS" \
 		-o "${out}/etcd" ${REPO_PATH} || return
 	# shellcheck disable=SC2086
-	CGO_ENABLED=0 go build $GO_BUILD_FLAGS \
+	CGO_ENABLED=0 go build ${GO_BUILD_FLAGS:-} \
 		-installsuffix cgo \
 		-ldflags "$GO_LDFLAGS" \
 		-o "${out}/etcdctl" ${REPO_PATH}/etcdctl || return
@@ -66,7 +68,7 @@ etcd_build() {
 
 tools_build() {
 	out="bin"
-	if [[ -n "${BINDIR}" ]]; then out="${BINDIR}"; fi
+	if [[ -n "${BINDIR:-}" ]]; then out="${BINDIR}"; fi
 	tools_path="tools/benchmark
 	tools/etcd-dump-db
 	tools/etcd-dump-logs
@@ -88,7 +90,7 @@ tools_build() {
 
 toggle_failpoints_default
 
-if [[ "${ETCD_SETUP_GOPATH}" == "1" ]]; then
+if [[ "${ETCD_SETUP_GOPATH:-}" == "1" ]]; then
 	etcd_setup_gopath
 fi
 

--- a/functional/build
+++ b/functional/build
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 if ! [[ "$0" =~ "functional/build" ]]; then
   echo "must be run from repository root"
   exit 255

--- a/test
+++ b/test
@@ -31,9 +31,11 @@
 # Run code coverage
 # COVERDIR must either be a absolute path or a relative path to the etcd root
 # $ COVERDIR=coverage PASSES="build_cov cov" ./test
-set -e
+set -euo pipefail
 
 source ./build
+
+PASSES=${PASSES:-}
 
 # build before setting up test GOPATH
 if [[ "${PASSES}" == *"functional"* ]]; then
@@ -82,6 +84,7 @@ fi
 
 # shellcheck disable=SC2206
 FMT=($FMT)
+VERBOSE=${VERBOSE:-}
 if [ "${VERBOSE}" == "1" ]; then
 	# shellcheck disable=SC2128
 	echo "Running with FMT:" "${FMT[@]}"
@@ -108,19 +111,20 @@ if [ "${VERBOSE}" == "1" ]; then
 	echo "Running with STATIC_ANALYSIS_PATHS:" "${STATIC_ANALYSIS_PATHS[@]}"
 fi
 
+GOARCH=${GOARCH:-}
 if [ -z "$GOARCH" ]; then
 	GOARCH=$(go env GOARCH);
 fi
 
 # determine the number of CPUs to use for Go tests
 TEST_CPUS="1,2,4"
-if [ -n "${CPU}" ]; then
+if [ -n "${CPU:-}" ]; then
 	TEST_CPUS="${CPU}"
 fi
 echo "Running with TEST_CPUS:" "${TEST_CPUS}"
 
 # determine whether target supports race detection
-if [ -z "${RACE}" ] ; then
+if [ -z "${RACE:-}" ] ; then
   if [ "$GOARCH" == "amd64" ]; then
     RACE="--race"
   else
@@ -130,10 +134,13 @@ else
   RACE="--race=${RACE:-true}"
 fi
 
+TESTCASE=${TESTCASE:-}
 RUN_ARG=""
 if [ -n "${TESTCASE}" ]; then
 	RUN_ARG="-run=${TESTCASE}"
 fi
+
+TIMEOUT=${TIMEOUT:-}
 
 function unit_pass {
 	echo "Running unit tests..."
@@ -203,9 +210,10 @@ function integration_extra {
 }
 
 function functional_pass {
-  	# Clean up any data and logs from previous runs
-  	rm -rf /tmp/etcd-functional-* /tmp/etcd-functional-*.backup
+	# Clean up any data and logs from previous runs
+	rm -rf /tmp/etcd-functional-* /tmp/etcd-functional-*.backup
 
+	local agent_pids=""
 	for a in 1 2 3; do
 		./bin/etcd-agent --network tcp --address 127.0.0.1:${a}9027 &
 		pid="$!"
@@ -256,7 +264,7 @@ function cov_pass {
 		exit 255
 	fi
 
-	if [ -z "$COVERDIR" ]; then
+	if [ -z "${COVERDIR:-}" ]; then
 		echo "COVERDIR undeclared"
 		exit 255
 	fi
@@ -357,7 +365,7 @@ function release_pass {
 	rm -f ./bin/etcd-last-release
 	# to grab latest patch release; bump this up for every minor release
 	UPGRADE_VER=$(git tag -l --sort=-version:refname "v3.3.*" | head -1)
-	if [ -n "$MANUAL_VER" ]; then
+	if [ -n "${MANUAL_VER:-}" ]; then
 		# in case, we need to test against different version
 		UPGRADE_VER=$MANUAL_VER
 	fi
@@ -429,13 +437,13 @@ function goword_pass {
 		# shellcheck disable=SC2206
 		gofiles=($gofiles)
 		# only check for broken exported godocs
-		gowordRes=$(goword -use-spell=false "${gofiles[@]}" | grep godoc-export | sort)
+		gowordRes=$(goword -use-spell=false "${gofiles[@]}" | grep godoc-export | sort) || true
 		if [ -n "$gowordRes" ]; then
 			echo -e "goword checking failed:\\n${gowordRes}"
 			exit 255
 		fi
 		# check some spelling
-		gowordRes=$(goword -ignore-file=.words clientv3/{*,*/*}.go 2>&1 | grep spell | sort)
+		gowordRes=$(goword -ignore-file=.words clientv3/{*,*/*}.go 2>&1 | grep spell | sort) || true
 		if [ -n "$gowordRes" ]; then
 			echo -e "goword checking failed:\\n${gowordRes}"
 			exit 255
@@ -575,7 +583,7 @@ function receiver_name_pass {
 	# shellcheck disable=SC1117
 	recvs=$(grep 'func ([^*]' {*,*/*,*/*/*}.go  | grep -Ev "(generated|pb/)" | tr  ':' ' ' |  \
 		awk ' { print $2" "$3" "$4" "$1 }' | sed "s/[a-zA-Z\.]*go//g" |  sort  | uniq  | \
-		grep -Ev  "(Descriptor|Proto|_)"  | awk ' { print $3" "$4 } ' | sort | uniq -c | grep -v ' 1 ' | awk ' { print $2 } ')
+		grep -Ev  "(Descriptor|Proto|_)"  | awk ' { print $3" "$4 } ' | sort | uniq -c | grep -v ' 1 ' | awk ' { print $2 } ') || true
 	if [ -n "${recvs}" ]; then
 		# shellcheck disable=SC2206
 		recvs=($recvs)
@@ -588,7 +596,10 @@ function receiver_name_pass {
 }
 
 function commit_title_pass {
-	git log --oneline "$(git merge-base HEAD "$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}")")"...HEAD | while read -r l; do
+	local commitID
+
+	commitID="$(git merge-base HEAD "$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}")")" || return $?
+	git log --oneline "${commitID}"...HEAD | while read -r l; do
 		commitMsg=$(echo "$l" | cut -f2- -d' ')
 		if [[ "$commitMsg" == Merge* ]]; then
 			# ignore "Merge pull" commits
@@ -637,9 +648,10 @@ function fmt_pass {
 
 function bom_pass {
 	if ! command -v license-bill-of-materials >/dev/null; then
+		echo "Skipping bom..."
 		return
 	fi
-	if [ "${GO111MODULE}" == "on" ]; then
+	if [ "${GO111MODULE:-on}" == "on" ]; then
 		# license-bill-off-materials calls "go list std cmd" which cannot handle modules
 		# Please see https://github.com/golang/go/issues/26924
 		echo "Skipping license-bill-of-materials with go modules..."


### PR DESCRIPTION
By default, the pipefail is disabled. And Git
For instance, the commands should
return 1 as exit code, but we get zero. After pipefail enabled, it's back to normal.

```bash
$ ( echo hello; exit 1 ) | tee 2>&1
hello
$ echo $?
0

$ set -o pipefail
$ ( echo hello; exit 122 ) | tee 2>&1
hello
$ echo $?
122
```

And the test.log is used to grep the error from a ton of messages. So that we should `set +e` and set it back after egrep.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
